### PR TITLE
Commit search sellers and search orders

### DIFF
--- a/graphql/types/global.graphql
+++ b/graphql/types/global.graphql
@@ -5,6 +5,7 @@ type SearchResponse {
   dateStart: String
   dateEnd: String
   sellers: [SellersDashboardSearch]
+  statistics: StatsGeneralSearch
   pagination: PaginationSearch
 }
 
@@ -60,6 +61,7 @@ input SearchOrdersParams {
   sellerName: String!
   page: Int!
   perpage: Int!
+  status: String
 }
 
 type OrderSearch {

--- a/node/middlewares/dashboard/generate/calculateCommissionByOrder.ts
+++ b/node/middlewares/dashboard/generate/calculateCommissionByOrder.ts
@@ -15,10 +15,11 @@ export async function calculateCommissionByOrder(
       const totalComission = orderData.items.reduce(
         (total, x) =>
           total +
-          (formatVtexNumber(x.price) *
-            formatVtexNumber(formatVtexNumber(x.commission)) +
-            formatVtexNumber(x.shippingPrice ?? 0) *
-              formatVtexNumber(formatVtexNumber(x.freightCommission ?? 0))),
+          x.quantity *
+            (formatVtexNumber(x.price) *
+              formatVtexNumber(formatVtexNumber(x.commission)) +
+              formatVtexNumber(x.shippingPrice ?? 0) *
+                formatVtexNumber(formatVtexNumber(x.freightCommission ?? 0))),
         0
       )
 

--- a/node/middlewares/dashboard/search/calculateSellersSearch.ts
+++ b/node/middlewares/dashboard/search/calculateSellersSearch.ts
@@ -5,19 +5,22 @@ export async function calculateSellersSearch(
   const calculateSellers: SellersDashboard[] = []
 
   unificationSellers.forEach((item) => {
-    const ordersCount = item.statistics.reduce(
-      (total, x) => (total += x.ordersCount),
-      0
+    const ordersCount = Number(
+      item.statistics
+        .reduce((total, x) => (total += x.ordersCount), 0)
+        .toFixed(2)
     )
 
-    const totalComission = item.statistics.reduce(
-      (total, x) => (total += x.totalComission),
-      0
+    const totalComission = Number(
+      item.statistics
+        .reduce((total, x) => (total += x.totalComission), 0)
+        .toFixed(2)
     )
 
-    const totalOrderValue = item.statistics.reduce(
-      (total, x) => (total += x.totalOrderValue),
-      0
+    const totalOrderValue = Number(
+      item.statistics
+        .reduce((total, x) => (total += x.totalOrderValue), 0)
+        .toFixed(2)
     )
 
     const outstandingBalance = 0

--- a/node/middlewares/dashboard/search/searchSellers.ts
+++ b/node/middlewares/dashboard/search/searchSellers.ts
@@ -7,10 +7,20 @@ export async function searchSellers(ctx: Context, next: () => Promise<any>) {
   const sellersId = ctx.query.sellersId as string
   const page = Number(ctx.query.page)
   const pageSize = Number(ctx.query.pageSize)
+  const reIndex = JSON.parse(
+    (ctx.query.reIndex as string) ?? 'false'
+  ) as boolean
 
   await validationParams('Sellers', ctx.query)
 
-  const searchSellersParams = { dateStart, dateEnd, sellersId, page, pageSize }
+  const searchSellersParams = {
+    dateStart,
+    dateEnd,
+    sellersId,
+    page,
+    pageSize,
+    reIndex,
+  }
 
   const { status, result } = await searchSellersService(
     searchSellersParams,

--- a/node/middlewares/orders/orderDetailCommission.ts
+++ b/node/middlewares/orders/orderDetailCommission.ts
@@ -12,19 +12,25 @@ export async function orderDetailCommission(
     orderListBySeller.list.map(async (order) => {
       const orderData = await ordersClient.getOrder(order.orderId)
 
-      const totalComission = orderData.items.reduce(
-        (total, x) =>
-          total +
-          (formatVtexNumber(x.price) *
-            formatVtexNumber(formatVtexNumber(x.commission)) +
-            formatVtexNumber(x.shippingPrice ?? 0) *
-              formatVtexNumber(formatVtexNumber(x.freightCommission ?? 0))),
-        0
+      const totalComission = Number(
+        orderData.items
+          .reduce(
+            (total, x) =>
+              total +
+              x.quantity *
+                (formatVtexNumber(x.price) *
+                  formatVtexNumber(formatVtexNumber(x.commission)) +
+                  formatVtexNumber(x.shippingPrice ?? 0) *
+                    formatVtexNumber(
+                      formatVtexNumber(x.freightCommission ?? 0)
+                    )),
+            0
+          )
+          .toFixed(2)
       )
 
-      const totalOrderValue = orderData.items.reduce(
-        (total, x) => (total += formatVtexNumber(x.price)),
-        0
+      const totalOrderValue = Number(
+        formatVtexNumber(orderData.value).toFixed(2)
       )
 
       const itemsRate: ItemsRate[] = orderData.items.map((item) => {
@@ -32,8 +38,12 @@ export async function orderDetailCommission(
           itemId: item.id,
           nameItem: item.name,
           rate: {
-            freightCommissionPercentage: item.freightCommission,
-            productCommissionPercentage: item.commission,
+            freightCommissionPercentage: Number(
+              formatVtexNumber(item.freightCommission).toFixed(2)
+            ),
+            productCommissionPercentage: Number(
+              formatVtexNumber(item.commission).toFixed(2)
+            ),
           },
         }
       })

--- a/node/middlewares/orders/orderListSeller.ts
+++ b/node/middlewares/orders/orderListSeller.ts
@@ -5,14 +5,17 @@ export async function orderListSeller(
   dateStart: string,
   dateEnd: string,
   page: number,
-  perpage: number
+  perpage: number,
+  status?: string
 ): Promise<VtexListOrder> {
   const {
     clients: { ordersClient },
   } = ctx
 
+  console.info({ status })
+
   const orderList = await ordersClient.listOrders({
-    fStatus: '',
+    fStatus: status ?? '',
     fieldDate: 'creationDate',
     fieldDateStart: `${dateStart}T00:00:00.000Z`,
     fieldDateEnd: `${dateEnd}T23:59:59.999Z`,

--- a/node/middlewares/orders/orders.ts
+++ b/node/middlewares/orders/orders.ts
@@ -7,10 +7,18 @@ export async function orders(ctx: Context, next: () => Promise<Sellers>) {
   const sellerName = ctx.query.sellerName as string
   const page = Number(ctx.query.page)
   const perpage = Number(ctx.query.perpage)
+  const statusVtex = ctx.query.status as string
 
   await validationParams('Orders', ctx.query)
 
-  const searchOrdersParams = { dateStart, dateEnd, sellerName, page, perpage }
+  const searchOrdersParams = {
+    dateStart,
+    dateEnd,
+    sellerName,
+    page,
+    perpage,
+    status: statusVtex,
+  }
 
   const { status, resultDetail } = await searchOrdersService(
     searchOrdersParams,

--- a/node/routes.ts
+++ b/node/routes.ts
@@ -55,7 +55,7 @@ const routes = {
     GET: [errorHandler, eligibleSellers, generateInvoices],
   }),
   orders: method({
-    POST: [seller, authentication, orders],
+    GET: [seller, authentication, orders],
   }),
   token: method({
     POST: [seller, createTokenAuth],

--- a/node/service.json
+++ b/node/service.json
@@ -57,7 +57,7 @@
       "public": true
     },
     "orders": {
-      "path": "/_v/orders",
+      "path": "/_v/private/orders",
       "public": true
     },
     "token": {

--- a/node/services/searchOrdersService.ts
+++ b/node/services/searchOrdersService.ts
@@ -7,6 +7,8 @@ export const searchOrdersService = async (
 ) => {
   const { dateStart, dateEnd, sellerName, page, perpage } = searchOrdersParams
 
+  const status = searchOrdersParams.status as string
+
   console.info(sellerName)
 
   const listOrders = await orderListSeller(
@@ -15,7 +17,8 @@ export const searchOrdersService = async (
     dateStart,
     dateEnd,
     page,
-    perpage
+    perpage,
+    status
   )
 
   const ordersDetailCommission = await orderDetailCommission(ctx, listOrders)

--- a/node/services/searchStatisticsService.ts
+++ b/node/services/searchStatisticsService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/restrict-plus-operands */
 import type { StatisticsDashboard } from 'vtex.marketplace-financial-commission'
 
 export const searchStatisticsService = async (
@@ -26,21 +27,24 @@ export const searchStatisticsService = async (
 
   const statisticsArray = responseSearchMD.data as StatisticsDashboard[]
 
-  const ordersCount = statisticsArray.reduce(
-    (total, count) => (total += count.statistics.ordersCount),
-    0
+  const ordersCount = Number(
+    statisticsArray
+      .reduce((total, count) => (total += count.statistics.ordersCount), 0)
+      .toFixed(2)
   ) as number
 
   console.info({ ordersCount })
 
-  const totalComission = statisticsArray.reduce(
-    (total, comis) => (total += comis.statistics.totalComission),
-    0
+  const totalComission = Number(
+    statisticsArray
+      .reduce((total, comis) => (total += comis.statistics.totalComission), 0)
+      .toFixed(2)
   )
 
-  const totalOrderValue = statisticsArray.reduce(
-    (total, value) => (total += value.statistics.totalOrderValue),
-    0
+  const totalOrderValue = Number(
+    statisticsArray
+      .reduce((total, value) => (total += value.statistics.totalOrderValue), 0)
+      .toFixed(2)
   )
 
   const statistics: StatsSeller = {

--- a/node/typings/global.d.ts
+++ b/node/typings/global.d.ts
@@ -79,6 +79,7 @@ declare global {
     sellersId?: string
     page: number
     pageSize: number
+    reIndex?: boolean
   }
 
   interface SearchStatsServiceRequest {
@@ -92,6 +93,7 @@ declare global {
     sellerName: string
     page: number
     perpage: number
+    status?: string
   }
 
   interface Settings {


### PR DESCRIPTION
- Calculation of the statistics is performed at the moment that the front makes a request for one or more sellerId.

- Adjust search dashboard and search orders pagination.

- Sort sellers array by Id

- Adjusted saving in VBase, so that an empty array is not saved and if an empty array exists, it is generated again.
 
- Optional parameter 'reIndex' is added, with the function to re-generate the data that is saved in VBase in the MD query. Applies only to API Rest service

- In the information to show adjust total value of the order including shipping.

- Add optional parameter 'status' and perform query of the orders with the filter.